### PR TITLE
fix(health): align WorkoutSummary keys with Android and remove duplicate iOS properties

### DIFF
--- a/packages/health/ios/Classes/HealthDataReader.swift
+++ b/packages/health/ios/Classes/HealthDataReader.swift
@@ -248,12 +248,6 @@ class HealthDataReader {
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
                             : HealthConstants.RecordingMethod.automatic.rawValue,
-                        "workout_type": HKWorkoutActivityType.toString(sample.workoutActivityType),
-                        "total_distance": sample.totalDistance != nil
-                            ? Int(sample.totalDistance!.doubleValue(for: HKUnit.meter())) : 0,
-                        "total_energy_burned": sample.totalEnergyBurned != nil
-                            ? Int(sample.totalEnergyBurned!.doubleValue(for: HKUnit.kilocalorie()))
-                            : 0,
                     ]
                 }
 
@@ -511,12 +505,6 @@ class HealthDataReader {
                             (sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool == true)
                             ? HealthConstants.RecordingMethod.manual.rawValue
                             : HealthConstants.RecordingMethod.automatic.rawValue,
-                        "workout_type": HKWorkoutActivityType.toString(sample.workoutActivityType),
-                        "total_distance": sample.totalDistance != nil
-                            ? Int(sample.totalDistance!.doubleValue(for: HKUnit.meter())) : 0,
-                        "total_energy_burned": sample.totalEnergyBurned != nil
-                            ? Int(sample.totalEnergyBurned!.doubleValue(for: HKUnit.kilocalorie()))
-                            : 0,
                     ]
                 }
 

--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -147,10 +147,10 @@ class HealthDataPoint {
 
     // Set WorkoutSummary, if available.
     WorkoutSummary? workoutSummary;
-    if (dataPoint["workout_type"] != null ||
-        dataPoint["total_distance"] != null ||
-        dataPoint["total_energy_burned"] != null ||
-        dataPoint["total_steps"] != null) {
+    if (dataPoint["workoutActivityType"] != null ||
+        dataPoint["totalDistance"] != null ||
+        dataPoint["totalEnergyBurned"] != null ||
+        dataPoint["totalSteps"] != null) {
       workoutSummary = WorkoutSummary.fromHealthDataPoint(dataPoint);
     }
 

--- a/packages/health/lib/src/workout_summary.dart
+++ b/packages/health/lib/src/workout_summary.dart
@@ -30,10 +30,10 @@ class WorkoutSummary {
   /// Create a [WorkoutSummary] based on a health data point from native data format.
   factory WorkoutSummary.fromHealthDataPoint(dynamic dataPoint) =>
       WorkoutSummary(
-        workoutType: dataPoint['workout_type'] as String? ?? '',
-        totalDistance: dataPoint['total_distance'] as num? ?? 0,
-        totalEnergyBurned: dataPoint['total_energy_burned'] as num? ?? 0,
-        totalSteps: dataPoint['total_steps'] as num? ?? 0,
+        workoutType: dataPoint['workoutActivityType'] as String? ?? '',
+        totalDistance: dataPoint['totalDistance'] as num? ?? 0,
+        totalEnergyBurned: dataPoint['totalEnergyBurned'] as num? ?? 0,
+        totalSteps: dataPoint['totalSteps'] as num? ?? 0,
       );
 
   /// Create a [HealthDataPoint] from json.


### PR DESCRIPTION
### Summary

This PR fixes a mismatch between the keys returned by the native Android implementation and those expected by the Dart layer when creating a `WorkoutSummary`.

### Problem

* The **Android layer** returns workout properties in **camelCase** (`totalDistance`, `totalEnergyBurned`, etc.).
* The **Dart layer** was expecting **snake_case** (`total_distance`, `total_energy_burned`, etc.).
* The **iOS layer** returned **both camelCase and snake_case**.

This mismatch caused `WorkoutSummary` values to be unavailable when reading workouts from Android.

### Changes

* Updated Dart’s `WorkoutSummary.fromHealthDataPoint` and related checks to use **camelCase keys** (matching Android and also iOS).
* Removed the duplicate snake_case properties from iOS (`workout_type`, `total_distance`, `total_energy_burned`).
* Ensured consistency between Android, iOS, and Dart layers.

### Impact

* Fixes `WorkoutSummary` parsing for Android.
* Cleans up unused keys from iOS without changing Dart’s expectations.
* No breaking change for public Dart API (users continue to consume `WorkoutSummary` the same way).
