### PR TITLE
chore(mobility_features): widen carp_serializable constraint to allow 3.x (6.2.0)

### DIFF
--- a/packages/mobility_features/CHANGELOG.md
+++ b/packages/mobility_features/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.2.0
 
-* widen `carp_serializable` constraint to allow 3.x
+* upgrade to `carp_serializable` ^3.0.0
 
 ## 6.1.0
 

--- a/packages/mobility_features/CHANGELOG.md
+++ b/packages/mobility_features/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0
+
+* widen `carp_serializable` constraint to allow 3.x
+
 ## 6.1.0
 
 * upgrade of stats package

--- a/packages/mobility_features/pubspec.yaml
+++ b/packages/mobility_features/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobility_features
 description: Calculation of real-time mobility features like places, stops, and home stay
-version: 6.1.0
+version: 6.2.0
 homepage: https://github.com/cph-cachet/flutter-plugins/
 
 environment:
@@ -14,7 +14,7 @@ dependencies:
   stats: ^3.0.0
   path_provider: ^2.0.2
   json_annotation: ^4.8.0
-  carp_serializable: ^2.0.0
+  carp_serializable: '>=2.0.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/mobility_features/pubspec.yaml
+++ b/packages/mobility_features/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   stats: ^3.0.0
   path_provider: ^2.0.2
   json_annotation: ^4.8.0
-  carp_serializable: '>=2.0.0 <4.0.0'
+  carp_serializable: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Widens the `carp_serializable` constraint so `mobility_features` works with both 2.x and 3.x.

`carp_serializable 3.0.0` is a breaking release (it replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package). Today `mobility_features` pins `^2.0.0`, which blocks `carp_context_package` in `carp.sensing-flutter` from resolving.

## Change

- `carp_serializable: ^2.0.0` → `'>=2.0.0 <4.0.0'`
- version `6.1.0` → `6.2.0`

A range rather than `^3.0.0` keeps existing 2.x consumers working, so this is non-breaking for downstream users.

## No code changes needed

The only breaking change in 3.0.0 is `Uuid().v1` (getter) → `const Uuid().v4()` (method). `lib/` has no `Uuid` references, so this is a constraint-only bump.

## Verification

- resolves `carp_serializable 3.0.0`
- `flutter test`: the 4 failing tests in `mobility_features_test.dart` fail identically on unmodified `master` (`FormatException` while parsing test data) — pre-existing and unrelated to this change.

This one is independent of the other repos and can be merged/published on its own.
